### PR TITLE
Add more commentary on `max_grow`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,15 @@ start_full= can be 0 or 1 (or True or False) to indicate starting the window
 
 default_resolution= expressed as numbers separated by an 'x' (e.g. 640x480)
 
-max_grow= specifies the maximum amount a picture may be enlarged
-  This is an integer (e.g. 5).  The value '2' would limit the enlargment
-  to 200%.  This is to keep small pictures from becoming
-  too pixelated when upscaling them.  Image are automaticaly downscaled
-  if they are too big for the current window, and upscaled (up to
-  a factor of 'max_grow') when they are smaller then the current window.
+max_size= specifies the maximum size a picture can be as a percentage of its
+  original size
+  This is a float (e.g. 2.3, 1.0, etc.).  The value '2.0' would limit the
+  enlargment to 200%.  This is generally used to keep small pictures from
+  becoming too pixelated when upscaling them, although technically one could
+  set this to a percentage smaller than 100% (with a value less than 1.0).
+  Images are automaticaly downscaled if they are too big for the current
+  window, and upscaled ([or resized] to a factor of 'max_size') when they
+  are smaller then the current window.
 
 cache_dir= specifies the directory to be used for caching images
 

--- a/bird-slideshow.cfg
+++ b/bird-slideshow.cfg
@@ -4,5 +4,5 @@ source=ssh:ssuser:password@example-host.com:/home/ssuser/Pictures
 wait_time=1.5
 start_full=True
 default_resolution=958x720
-max_grow=5
+max_size=5
 cache_dir=cache

--- a/bird-slideshow.py
+++ b/bird-slideshow.py
@@ -88,7 +88,7 @@ class Config:  # pylint: disable=R0902
                     self.start_full = TRUTH_TABLE[value.capitalize()]
                 elif name == "default_resolution":
                     self.win_start_res = value
-                elif name == "max_grow":
+                elif name == "max_size":
                     self.max_size = float(value)
                 elif name == "cache_dir":
                     self.cache_dir = value
@@ -110,7 +110,7 @@ class Config:  # pylint: disable=R0902
         value = input("Start in fullscreen mode (True/False): ")
         self.start_full = TRUTH_TABLE[value.capitalize()]
         self.win_start_res = input("Window resolution (in the form '{width}x{height}'): ")
-        self.max_size = float(input("Max growth factor for image resizing (2 = 200%): "))
+        self.max_size = float(input("Max size factor for image resizing (2 = 200%): "))
         self.cache_dir = input("Directory for cache: ")
 
     def _convert_win_res(self):
@@ -748,9 +748,9 @@ def resize_img(img: Image.Image) -> Image.Image:
     h_scale_factor: float = win_height/img_h
 
     # Picks the minimum between the vertical or horizontal scale factor, then takes the minimum
-    # between the scale factor and the max_grow configuration setting.
+    # between the scale factor and the max_size configuration setting.
     scale_factor = min(min(w_scale_factor, h_scale_factor), config.max_size)
-    # print(f"DEBUG: scale_factor = {scale_factor}, config.max_grow = {config.max_grow}")
+    # print(f"DEBUG: scale_factor = {scale_factor}, config.max_size = {config.max_size}")
 
     if scale_factor < .95 or scale_factor > 1.05:
         return img.resize((int(img_w*scale_factor), int(img_h*scale_factor)))

--- a/bird-slideshow.py
+++ b/bird-slideshow.py
@@ -54,7 +54,7 @@ class Config:  # pylint: disable=R0902
         self.win_start_res: str = "958x720"
         self.win_start_width: int = 958
         self.win_start_height: int = 720
-        self.max_grow: float = 4.0
+        self.max_size: float = 4.0
         self.cache_dir: str = "cache"
 
         self.config_file: str = config_file
@@ -89,7 +89,7 @@ class Config:  # pylint: disable=R0902
                 elif name == "default_resolution":
                     self.win_start_res = value
                 elif name == "max_grow":
-                    self.max_grow = float(value)
+                    self.max_size = float(value)
                 elif name == "cache_dir":
                     self.cache_dir = value
                 else:
@@ -110,7 +110,7 @@ class Config:  # pylint: disable=R0902
         value = input("Start in fullscreen mode (True/False): ")
         self.start_full = TRUTH_TABLE[value.capitalize()]
         self.win_start_res = input("Window resolution (in the form '{width}x{height}'): ")
-        self.max_grow = float(input("Max growth factor for image resizing (2 = 200%): "))
+        self.max_size = float(input("Max growth factor for image resizing (2 = 200%): "))
         self.cache_dir = input("Directory for cache: ")
 
     def _convert_win_res(self):
@@ -744,15 +744,13 @@ def resize_img(img: Image.Image) -> Image.Image:
     """
 
     img_w, img_h = img.size
-    w_scale_factor = win_width/img_w
-    h_scale_factor = win_height/img_h
+    w_scale_factor: float = win_width/img_w
+    h_scale_factor: float = win_height/img_h
 
-    scale_factor = min(min(w_scale_factor, h_scale_factor), config.max_grow)
-    # scale_factor = min(w_scale_factor, h_scale_factor)
-
-    # print("DEBUG", scale_factor, MAX_GROW)
-
-    # print("DEBUG", img_w, img_h, scale_factor, win_width, win_height)
+    # Picks the minimum between the vertical or horizontal scale factor, then takes the minimum
+    # between the scale factor and the max_grow configuration setting.
+    scale_factor = min(min(w_scale_factor, h_scale_factor), config.max_size)
+    # print(f"DEBUG: scale_factor = {scale_factor}, config.max_grow = {config.max_grow}")
 
     if scale_factor < .95 or scale_factor > 1.05:
         return img.resize((int(img_w*scale_factor), int(img_h*scale_factor)))


### PR DESCRIPTION
`max_grow` doesn't work as described in the README, so some adjustments were made to accurately reflect what it does in resizing PIL images.

Changed the name `max_grow` to `max_size` to more accurately reflect its role in the program.

Resolves issue #24.